### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > _Thank you for filing a bug ticket. We very much appreciate your time._
+  - type: dropdown
+    id: checked-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issues?
+      multiple: false
+      options:
+        - "Yes - I've already checked"
+        - "No - I haven't checked"
+    validations:
+      required: yes
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. Plain-text snippets preferred but screenshots welcome.
+      placeholder: Tell us what you saw
+      value: "When I did [...] action, I noticed [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What did you expect?
+      description: A clear and concise description of what you expect to happen
+      placeholder: Tell us what you expected
+      value: "I expected [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproducible steps
+      description: "How would we reproduce this bug? Please walk us through it step by step. Plain-text snippets preferred but screenshots welcome."
+      value: |
+        1.
+        2.
+        3.
+        ...
+      render: bash
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "What is your environment?"
+      value: |
+        - Version of this software [e.g. vX.Y.Z]
+        - Operating System: [e.g. MacOSX with Docker Desktop vX.Y]
+        ...
+      render: bash

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: New Feature
+description: Submit a new feature request
+title: "[New Feature]: "
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > _Thank you for filing a new feature request. We very much appreciate your time._
+  - type: dropdown
+    id: checked-duplicates
+    attributes:
+      label: Checked for duplicates
+      description: Have you checked for duplicate issues?
+      multiple: false
+      options:
+        - "Yes - I've already checked"
+        - "No - I haven't checked"
+    validations:
+      required: yes
+  - type: dropdown
+    id: checked-alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered alternative solutions to your feature request?
+      options:
+        - "Yes - and alternatives don't suffice"
+        - "No - I haven't considered"
+    validations:
+      required: yes
+  - type: textarea
+    id: feature-problem
+    attributes:
+      label: Related problem
+      description: Is your feature request related to a problem? Please help us understand if so.
+      placeholder: Tell us the problem
+      value: "Ex. I'm frustrated when [...] happens"
+    validations:
+      required: false
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature request
+      description: A clear and concise description of your request. 
+      placeholder: Tell us what you want
+      value: "Ex. I need or want [...]"
+    validations:
+      required: true


### PR DESCRIPTION
New GitHub template forms for bug reports and new feature requests. For live example, check out: https://github.com/nasa/opera-sds-pge/issues/new/choose. Both templates automatically tag issue with a new label 'needs triage. _This label needs to be manually created once for the repository for this automatic tagging to work_