### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
     validations:
       required: yes
   - type: textarea
-    id: bug-description
+    id: description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Plain-text snippets preferred but screenshots welcome.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,7 +29,7 @@ body:
     validations:
       required: yes
   - type: textarea
-    id: feature-problem
+    id: related-problem
     attributes:
       label: Related problem
       description: Is your feature request related to a problem? Please help us understand if so.
@@ -38,7 +38,7 @@ body:
     validations:
       required: false
   - type: textarea
-    id: feature-description
+    id: description
     attributes:
       label: Describe the feature request
       description: A clear and concise description of your request. 


### PR DESCRIPTION
New GitHub template forms for bug reports and new feature requests. For live example, check out: https://github.com/nasa/opera-sds-pge/issues/new/choose. Both templates automatically tag issue with a new label 'needs triage'. _This label needs to be manually created once for the repository for this automatic tagging to work_