### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > _Thank you for filing a bug ticket. We very much appreciate your time._
+        > _Thanks for filing a bug ticket. We appreciate your time and effort. Please answer a few questions._
   - type: dropdown
     id: checked-duplicates
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > _Thank you for filing a new feature request. We very much appreciate your time._
+        > _Thanks for filing a new feature request. We appreciate your time and effort. Please answer a few questions._
   - type: dropdown
     id: checked-duplicates
     attributes:


### PR DESCRIPTION
New GitHub template forms for bug reports and new feature requests. For live example, check out: https://github.com/nasa/opera-sds-pge/issues/new/choose. Both templates automatically tag issue with a new label 'needs triage'. _This label needs to be manually created once for the repository for this automatic tagging to work_