### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: checked-duplicates
     attributes:
       label: Checked for duplicates
-      description: Have you checked for duplicate issues?
+      description: Have you checked for duplicate issue tickets?
       multiple: false
       options:
         - "Yes - I've already checked"
@@ -24,7 +24,7 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Plain-text snippets preferred but screenshots welcome.
       placeholder: Tell us what you saw
-      value: "When I did [...] action, I noticed [...]"
+      value: "Whe I did [...] action, I noticed [...]"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
     id: checked-duplicates
     attributes:
       label: Checked for duplicates
-      description: Have you checked for duplicate issues?
+      description: Have you checked for duplicate issue tickets?
       multiple: false
       options:
         - "Yes - I've already checked"
@@ -32,9 +32,9 @@ body:
     id: related-problem
     attributes:
       label: Related problem
-      description: Is your feature request related to a problem? Please help us understand if so.
+      description: Is your feature request related to a problem? Please help us understand if so, including linking to any other issue tickets.
       placeholder: Tell us the problem
-      value: "Ex. I'm frustrated when [...] happens"
+      value: "I'm frustrated when [...] happens"
     validations:
       required: false
   - type: textarea
@@ -43,6 +43,6 @@ body:
       label: Describe the feature request
       description: A clear and concise description of your request. 
       placeholder: Tell us what you want
-      value: "Ex. I need or want [...]"
+      value: "I need or want [...]"
     validations:
       required: true


### PR DESCRIPTION
New GitHub template forms for bug reports and new feature requests. 
For live example, check out: https://github.com/nasa/opera-sds-sys/issues/new/choose. 
Both templates automatically tag issue with a new label "needs triage". _This label needs to be manually created once for the repository for this automatic tagging to work_"
