### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,12 +29,12 @@ body:
     validations:
       required: yes
   - type: textarea
-    id: related-problem
+    id: related-problems
     attributes:
-      label: Related problem
-      description: Is your feature request related to a problem? Please help us understand if so, including linking to any other issue tickets.
-      placeholder: Tell us the problem
-      value: "I'm frustrated when [...] happens"
+      label: Related problems
+      description: Is your feature request related to any problems? Please help us understand if so, including linking to any other issue tickets.
+      placeholder: Tell us the problems
+      value: "I'm frustrated when [...] happens as documented in issue-XYZ"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
* New GitHub template forms for bug reports and new feature requests. 
* For live example, check out: https://github.com/nasa/opera-sds-sys/issues/new/choose. 
* Both templates automatically tag issue with a new label "needs triage". _This label needs to be manually created once for the repository for this automatic tagging to work_"
