### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         > _Thanks for filing a bug ticket. We appreciate your time and effort. Please answer a few questions._
   - type: dropdown
-    id: checked-duplicates
+    id: checked-for-duplicates
     attributes:
       label: Checked for duplicates
       description: Have you checked for duplicate issue tickets?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         > _Thanks for filing a new feature request. We appreciate your time and effort. Please answer a few questions._
   - type: dropdown
-    id: checked-duplicates
+    id: checked-for-duplicates
     attributes:
       label: Checked for duplicates
       description: Have you checked for duplicate issue tickets?


### PR DESCRIPTION
* New GitHub template forms for bug reports and new feature requests. 
* For live example, check out: https://github.com/nasa/opera-sds-sys/issues/new/choose. 
* Both templates automatically tag issue with a new label "needs triage". _This label needs to be manually created once for the repository for this automatic tagging to work_".
  * Suggested label name: "needs triage"
  * Suggested description: "Issue requires triage to proceed"
  * Suggested color: "#C24247"
