### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Plain-text snippets preferred but screenshots welcome.
       placeholder: Tell us what you saw
-      value: "Whe I did [...] action, I noticed [...]"
+      value: "When I did [...] action, I noticed [...]"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
* New GitHub template forms for bug reports and new feature requests. 
* For live example, check out: https://github.com/nasa/opera-sds-sys/issues/new/choose. 
* Both templates automatically tag issue with a new label "needs triage". _This label needs to be manually created once for the repository for this automatic tagging to work_".
  * Suggested label name: "needs triage"
  * Suggested description: "Issue requires triage to proceed"
  * Suggested color: "#C24247"
